### PR TITLE
Feature/fix evaluator

### DIFF
--- a/src/gensie/eval.py
+++ b/src/gensie/eval.py
@@ -129,8 +129,7 @@ class Evaluator:
                     g_item,
                     s_item,
                     item_schema,
-                    root_schema=root_schema,
-                    input_text=input_text,
+                    root_schema=root_schema
                 )
                 row.append(sim)
             matrix.append(row)

--- a/src/gensie/eval.py
+++ b/src/gensie/eval.py
@@ -1,6 +1,7 @@
 import math
 import re
-from typing import Any, Dict, List
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def flatten_json(
@@ -39,6 +40,17 @@ def cosine_similarity(v1: List[float], v2: List[float]) -> float:
         return 0.0
     return dot_product(v1, v2) / (m1 * m2)
 
+
+
+@dataclass
+class GreedyMatchResult:
+    """Result of greedy bipartite matching between two lists."""
+
+    pairs: List[Tuple[int, int, float]] = field(default_factory=list)
+    unmatched_gold: List[int] = field(default_factory=list)
+    unmatched_system: List[int] = field(default_factory=list)
+    total: float = 0.0
+    
 
 class Evaluator:
     """
@@ -90,34 +102,41 @@ class Evaluator:
             curr = curr.get(p, {})
         return curr
 
-    def _greedy_match(
+    def _greedy_match_pairs(
         self,
         gold_list: List[Any],
         system_list: List[Any],
         item_schema: Dict[str, Any],
         root_schema: Dict[str, Any],
-    ) -> float:
+        input_text: Optional[str] = None,
+    ) -> GreedyMatchResult:
         """
-        Calculates similarity sum between two lists using Greedy Bipartite Matching.
+        Greedy Bipartite Matching returning matched pairs and unmatched indices.
         """
+        result = GreedyMatchResult()
+
         if not gold_list or not system_list:
-            return 0.0
+            result.unmatched_gold = list(range(len(gold_list)))
+            result.unmatched_system = list(range(len(system_list)))
+            return result
 
         # Precompute similarity matrix
         matrix = []
         for g_item in gold_list:
             row = []
             for s_item in system_list:
-                # Recursive score for nested items
                 sim = self.score_instance(
-                    g_item, s_item, item_schema, root_schema=root_schema
+                    g_item,
+                    s_item,
+                    item_schema,
+                    root_schema=root_schema,
+                    input_text=input_text,
                 )
                 row.append(sim)
             matrix.append(row)
 
-        matches = 0.0
-        used_g = set()
-        used_s = set()
+        used_g: set = set()
+        used_s: set = set()
 
         # Find best matches greedily
         while len(used_g) < len(gold_list) and len(used_s) < len(system_list):
@@ -135,13 +154,38 @@ class Evaluator:
                         best_pair = (i, j)
 
             if best_sim >= 0:
-                matches += best_sim
+                result.pairs.append((best_pair[0], best_pair[1], best_sim))
+                result.total += best_sim
                 used_g.add(best_pair[0])
                 used_s.add(best_pair[1])
             else:
                 break
 
-        return matches
+        result.unmatched_gold = [i for i in range(len(gold_list)) if i not in used_g]
+        result.unmatched_system = [
+            j for j in range(len(system_list)) if j not in used_s
+        ]
+        return result
+
+    def _greedy_match(
+        self,
+        gold_list: List[Any],
+        system_list: List[Any],
+        item_schema: Dict[str, Any],
+        root_schema: Dict[str, Any],
+        input_text: Optional[str] = None,
+    ) -> float:
+        """
+        Calculates similarity sum between two lists using Greedy Bipartite Matching.
+        """
+        return self._greedy_match_pairs(
+            gold_list,
+            system_list,
+            item_schema,
+            root_schema,
+            input_text=input_text,
+        ).total
+
 
     def compute_value_similarity(self, g_val: Any, s_val: Any, is_rigid: bool) -> float:
         """
@@ -239,8 +283,8 @@ class Evaluator:
                 if "$ref" in field_schema:
                     field_schema = self.resolve_ref(root_schema, field_schema["$ref"])
 
-                s_val = s_flat.get(k)
-                if s_val is not None:
+                if k in s_flat:
+                    s_val = s_flat[k]
                     total_similarity += self.score_instance(
                         g_val, s_val, field_schema, root_schema=root_schema
                     )


### PR DESCRIPTION
Fixes of this PR:

- Improving the algorithm for sorting the entities:


| Key                | Gold            | Value                | Score  | Match |
|--------------------|-----------------|----------------------|--------|-------|
| ORGANIZATION       | 0.0000          | 0.3036               |        | ✗     |
| entities.0.label   | PERSON          | PERSON               | 1.0000 | ✓     |
| entities.0.text    | Daisy Ridley    | Daisy Ridley         | 0.3253 | ✗     |
| entities.1.label   | PERSON          | LOCATION             | 0.0000 | ✗     |
| entities.1.text    | John McClane    | John McClane         | 0.3517 | ✗     |
| entities.2.label   | LOCATION        | MISCELLANEOUS        | 0.0000 | ✗     |
| entities.2.text    | Nakatomi        | Jungla de cristal    | 0.2933 | ✗     |
| entities.3.label   | ORGANIZATION    | MISCELLANEOUS        | 0.0000 | ✗     |
| entities.3.text    | Jungla de cristal | Cleaner: Rescate Vertical |        |       |
| entities.4.label   | MISSING         | MISSING              | 0.0000 | ✗     |
| entities.4.text    | Jungla de cristal | MISSING            | 0.0000 | ✗     

is now changed to:


| Key                   | Gold            | Value            | Score  | Match |
|-----------------------|-----------------|------------------|--------|-------|
| entities[0↔1].label   | PERSON          | PERSON           | 1.0000 | ✓     |
| entities[0↔1].text    | Daisy Ridley    | Daisy Ridley     | 1.0000 | ✓     |
| entities[1↔2].label   | PERSON          | PERSON           | 1.0000 | ✓     |
| entities[1↔2].text    | John McClane    | John McClane     | 1.0000 | ✓     |
| entities[3↔0].label   | MISCELLANEOUS   | ORGANIZATION     | 0.0000 | ✗     |
| entities[3↔0].text    | Cleaner: Rescate Vertical | Cleaner: Rescate Vertical | 1.0000 | ✓ |
| entities[4↔3].label   | MISCELLANEOUS   | ORGANIZATION     | 0.0000 | ✗     |
| entities[4↔3].text    | Jungla de cristal | Jungla de cristal | 1.0000 | ✓     |
| entities[2↔∅].label   | LOCATION        | MISSING          | 0.0000 | ∅     |
| entities[2↔∅].text    | Nakatomi        | MISSING          | 0.0000 | ∅     |


- Fixing wrong evaluation when gold and preds are None.

-  Current behaviour:
| Key | Gold Value | System Value | Score | Match |
| --- | --- | --- | ---: | :---: |
| body_type | LUNA | LUNA | 1.0000 | ✓ |
| diameter_km | None | None | 1.0000 | ✓ |
| discoverer | Christiaan Huygens | Christiaan Huygens | 1.0000 | ✓ |
| discovery_date | None | None | 1.0000 | ✓ |
| eccentricity | None | None | 1.0000 | ✓ |
| mass_kg | None | None | 1.0000 | ✓ |
| official_name | Titán | Titán | 1.0000 | ✓ |
| orbital_period_days | None | None | 1.0000 | ✓ |
| semi_major_axis_au | None | None | 1.0000 | ✓ |

**TPS:** 0.3333 · **P:** 0.3333 · **R:** 0.3333 · **F1:** 0.3333

In the current implementation None results are evaluated as wrong responses even when gold and preds have the same value of None.



