### PR TITLE
fix: correct flattened schema scoring tps

### DIFF
--- a/src/gensie/eval.py
+++ b/src/gensie/eval.py
@@ -110,7 +110,11 @@ class Evaluator:
             for s_item in system_list:
                 # Recursive score for nested items
                 sim = self.score_instance(
-                    g_item, s_item, item_schema, root_schema=root_schema
+                    g_item,
+                    s_item,
+                    item_schema,
+                    root_schema=root_schema,
+                    _normalize=True,
                 )
                 row.append(sim)
             matrix.append(row)
@@ -205,10 +209,11 @@ class Evaluator:
         system: Any,
         schema: Dict[str, Any],
         root_schema: Dict[str, Any] = None,
+        _normalize: bool = False,
     ) -> float:
         """
         Calculates Total Match Score (TMS) for a single instance or object.
-        Supports Jaccard Similarity for lists. Returns normalized 0-1 score.
+        Supports Jaccard Similarity for lists. Returns TPS unless _normalize=True.
         """
         if root_schema is None:
             root_schema = schema
@@ -239,14 +244,18 @@ class Evaluator:
                 if "$ref" in field_schema:
                     field_schema = self.resolve_ref(root_schema, field_schema["$ref"])
 
-                s_val = s_flat.get(k)
-                if s_val is not None:
+                if k in s_flat:
                     total_similarity += self.score_instance(
-                        g_val, s_val, field_schema, root_schema=root_schema
+                        g_val,
+                        s_flat[k],
+                        field_schema,
+                        root_schema=root_schema,
+                        _normalize=_normalize,
                     )
 
-            # Normalize by max possible keys (Precision/Recall blend at instance level)
-            return total_similarity / max(len(g_flat), len(s_flat))
+            if _normalize:
+                return total_similarity / max(len(g_flat), len(s_flat))
+            return total_similarity
 
         # Handle Lists (Bipartite Matching)
         if isinstance(gold, list):

--- a/tests/test_evaluator_v2.py
+++ b/tests/test_evaluator_v2.py
@@ -1,5 +1,9 @@
+from pathlib import Path
+
 import pytest
-from gensie.eval import Evaluator
+
+from gensie.eval import Evaluator, flatten_json
+from gensie.task import Task
 
 
 @pytest.fixture
@@ -74,11 +78,11 @@ def test_rigid_enum_matching(evaluator, entities_schema):
 
     # Label is enum, should be rigid (score 0.0)
     # Text is string, should be semantic (score 1.0)
-    # Total score = (0.0 + 1.0) / 2 = 0.5
+    # TPS = 0.0 + 1.0 = 1.0
 
     schema = entities_schema["$defs"]["Entity"]
     score = evaluator.score_instance(gold, system, schema, root_schema=entities_schema)
-    assert score == 0.5
+    assert score == 1.0
 
 
 def test_free_text_semantic_scoring(evaluator):
@@ -114,3 +118,36 @@ def test_nested_complex_matching(evaluator):
     # Strings in list should use semantic matching
     score = evaluator.score_instance(gold, system, schema)
     assert score > 0.4  # Better than 0.0
+
+
+def test_null_values_count_when_key_is_present(evaluator):
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "release_date": {
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+                "default": None,
+            },
+        },
+    }
+    gold = {"name": "GIMP", "release_date": None}
+
+    assert evaluator.score_instance(gold, gold, schema) == 2.0
+
+
+def test_perfect_starter_data_scores_one(evaluator):
+    tps_list = []
+    gold_counts = []
+    system_counts = []
+
+    for task_path in Path("data/starter").rglob("*.json"):
+        task = Task.load(task_path)
+        tps_list.append(
+            evaluator.score_instance(task.output, task.output, task.target_schema)
+        )
+        gold_counts.append(len(flatten_json(task.output, expand_lists=False)))
+        system_counts.append(len(flatten_json(task.output, expand_lists=False)))
+
+    metrics = evaluator.calculate_metrics(tps_list, gold_counts, system_counts)
+    assert metrics == {"precision": 1.0, "recall": 1.0, "f1": 1.0}


### PR DESCRIPTION
## Summary

This PR fixes the local evaluator implementation so it matches the metric definition in `docs/description.md` / the task description PDF.

The documented aggregation defines TPS as the sum of value similarities over shared flattened keys:

`TPS = sum Sim(G[k], S[k])`

Precision and recall are then computed globally as `TPS / |S|` and `TPS / |G|`. The current implementation was normalizing `score_instance()` at the object/instance level before passing the value to `calculate_metrics()`, which made the numerator too small.

## What was wrong

- `score_instance()` returned a normalized `0..1` instance score, but the CLI used that value as TPS.
- This effectively normalized the numerator before micro precision/recall were calculated.
- `null == null` fields did not contribute to TPS because object scoring used `s_flat.get(k)` and skipped values where `s_val is None`, even though the docs state that matching nulls score `1.0`.

## Fix

- `score_instance()` now returns unnormalized TPS by default.
- A private `_normalize=True` path is used only inside greedy list matching, where item-to-item similarities must remain on a `0..1` scale for the documented Jaccard normalization.
- Object scoring now checks `if k in s_flat` so present `null` values are scored correctly.
- The CLI contract remains unchanged: `calculate_metrics()` is still the only place where global precision, recall, and micro-F1 are computed.

## Metric evidence

Before the fix, evaluating perfect outputs on the 40 starter tasks (`system_output = gold`) produced a maximum F1 around `0.2153`, because TPS summed to only `38.1111` over `177` gold/system keys.

After the fix, the same perfect-output check produces:

```text
n 40 sum_tps 177.0 sum_g 177 sum_s 177 {"precision": 1.0, "recall": 1.0, "f1": 1.0}
```

I also reran the baseline with `qwen/qwen3-8b` after the metric correction and got:

```text
Precision 0.7198
Recall    0.6954
Micro-F1  0.7074
```

## Validation

```text
uv run pytest tests/test_evaluator_v2.py -q
8 passed

uv run pytest -q
10 passed
```

